### PR TITLE
PuzzlePlay Post API 추가

### DIFF
--- a/src/main/java/startoy/puzzletime/controller/PuzzlePlayController.java
+++ b/src/main/java/startoy/puzzletime/controller/PuzzlePlayController.java
@@ -1,0 +1,37 @@
+package startoy.puzzletime.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import startoy.puzzletime.dto.puzzlePlay.PuzzlePlayRequest;
+import startoy.puzzletime.dto.puzzlePlay.PuzzlePlayResponse;
+import startoy.puzzletime.service.PuzzlePlayService;
+import startoy.puzzletime.service.UserService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/puzzlePlays")
+@Tag(name = "PuzzlePlays", description = "PuzzlePlays API")
+public class PuzzlePlayController {
+
+    private final PuzzlePlayService puzzlePlayService;
+    private final UserService userService;
+
+    @Operation(summary = "Save Puzzle Play", description = "퍼즐 진행 상태를 저장합니다.")
+    @PostMapping("/{puzzleUid}")
+    public ResponseEntity<PuzzlePlayResponse> savePuzzlePlay(
+            @PathVariable @Parameter(description = "퍼즐 UID", required = true) String puzzleUid,
+            @RequestBody @Parameter(description = "퍼즐 진행 상태", required = true) PuzzlePlayRequest request,
+            OAuth2AuthenticationToken authentication) {
+        String userId = userService.getUserId(authentication);
+        PuzzlePlayResponse response = puzzlePlayService.savePuzzlePlay(puzzleUid, userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+
+}

--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
@@ -1,0 +1,10 @@
+package startoy.puzzletime.dto.puzzlePlay;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class PuzzlePlayRequest {
+    @NotNull
+    private String piecesData;
+}

--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
@@ -1,0 +1,14 @@
+package startoy.puzzletime.dto.puzzlePlay;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PuzzlePlayResponse {
+    private String puzzlePlayUid;
+    private String puzzleUid;
+    private Long userId;
+    private boolean isCompleted;
+    private String piecesData;
+}

--- a/src/main/java/startoy/puzzletime/repository/PuzzlePlayRepository.java
+++ b/src/main/java/startoy/puzzletime/repository/PuzzlePlayRepository.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Repository;
 import jakarta.persistence.ColumnResult;
 import jakarta.persistence.ConstructorResult;
 import jakarta.persistence.SqlResultSetMapping;
+import startoy.puzzletime.domain.Puzzle;
 import startoy.puzzletime.domain.PuzzlePlay;
+import startoy.puzzletime.domain.User;
 import startoy.puzzletime.dto.puzzle.GetPuzzleResponse;
 
 import java.util.Map;
@@ -65,4 +67,5 @@ public interface PuzzlePlayRepository extends JpaRepository<PuzzlePlay, Long> {
      *    and tpp.user_id = :userId				-- tb_puzzle_play 중 일치하는 사용자 정보 조회
      * #endregion */
 
+    Optional<PuzzlePlay> findByUserAndPuzzle(User user, Puzzle puzzle);
 }

--- a/src/main/java/startoy/puzzletime/repository/PuzzleRepository.java
+++ b/src/main/java/startoy/puzzletime/repository/PuzzleRepository.java
@@ -5,10 +5,12 @@ import startoy.puzzletime.domain.Puzzle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-
+import java.util.Optional;
 @Repository
 public interface PuzzleRepository extends JpaRepository<Puzzle, Long> {
 
     // artwork_id로 퍼즐 리스트 조회
     List<Puzzle> findByArtworkArtworkId(Long artworkId);
+
+    Optional<Puzzle> findByPuzzleUid(String puzzleUid);
 }

--- a/src/main/java/startoy/puzzletime/service/PuzzlePlayService.java
+++ b/src/main/java/startoy/puzzletime/service/PuzzlePlayService.java
@@ -1,0 +1,59 @@
+package startoy.puzzletime.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import startoy.puzzletime.domain.Puzzle;
+import startoy.puzzletime.domain.PuzzlePlay;
+import startoy.puzzletime.domain.User;
+import startoy.puzzletime.dto.puzzlePlay.PuzzlePlayRequest;
+import startoy.puzzletime.dto.puzzlePlay.PuzzlePlayResponse;
+import startoy.puzzletime.repository.PuzzlePlayRepository;
+import startoy.puzzletime.repository.PuzzleRepository;
+import startoy.puzzletime.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PuzzlePlayService {
+
+    private final PuzzlePlayRepository puzzlePlayRepository;
+    private final PuzzleRepository puzzleRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PuzzlePlayResponse savePuzzlePlay(String puzzleUid, String userId, PuzzlePlayRequest request) {
+        // 사용자 및 퍼즐 확인
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Puzzle puzzle = puzzleRepository.findByPuzzleUid(puzzleUid)
+                .orElseThrow(() -> new IllegalArgumentException("Puzzle not found"));
+
+        // 기존 퍼즐 진행 상태 조회
+        PuzzlePlay puzzlePlay = puzzlePlayRepository.findByUserAndPuzzle(user, puzzle)
+                .orElseGet(() -> PuzzlePlay.builder()
+                        .puzzlePlayUid(UUID.randomUUID().toString())
+                        .puzzle(puzzle)
+                        .user(user)
+                        .isCompleted(false)
+                        .createdAt(LocalDateTime.now())
+                        .build());
+
+        // 진행 상태 업데이트
+        puzzlePlay.setPiecesData(request.getPiecesData());
+        puzzlePlay.setUpdatedAt(LocalDateTime.now());
+
+        // 저장
+        PuzzlePlay savedPuzzlePlay = puzzlePlayRepository.save(puzzlePlay);
+        
+        return PuzzlePlayResponse.builder()
+                .puzzlePlayUid(savedPuzzlePlay.getPuzzlePlayUid())
+                .puzzleUid(savedPuzzlePlay.getPuzzle().getPuzzleUid())
+                .userId(savedPuzzlePlay.getUser().getId())
+                .isCompleted(savedPuzzlePlay.getIsCompleted())
+                .piecesData(savedPuzzlePlay.getPiecesData())
+                .build();
+    }
+}


### PR DESCRIPTION
PuzzlePlay Post API 추가
사용자 퍼즐 게임 진행 중 저장 시 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 퍼즐 플레이 활동을 관리하는 REST 컨트롤러 추가.
	- 퍼즐 플레이 상태를 저장하는 기능 구현.
	- 퍼즐 및 사용자에 따라 퍼즐 플레이를 검색하는 기능 추가.
	- 퍼즐의 고유 식별자로 퍼즐을 검색하는 기능 추가.

- **버그 수정**
	- 사용자 및 퍼즐 유효성 검사 기능 개선.

- **문서화**
	- OpenAPI 문서화 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->