### PR TITLE
feat: modify get puzzle api

### DIFF
--- a/src/main/java/startoy/puzzletime/domain/PuzzlePlay.java
+++ b/src/main/java/startoy/puzzletime/domain/PuzzlePlay.java
@@ -43,8 +43,8 @@ public class PuzzlePlay {
     @Column(name = "image_id", nullable = false)
     private Long imageId;
 
-    @Column(name = "pieces_data", columnDefinition = "json")
-    private String piecesData;
+    @Column(name = "puzzle_play_data", columnDefinition = "json")
+    private String puzzlePlayData;
 
     @NotNull
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/startoy/puzzletime/dto/puzzle/GetPuzzleResponse.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzle/GetPuzzleResponse.java
@@ -11,10 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class GetPuzzleResponse {
     private String puzzleUid;
-    private String imageUrl;
+    private String puzzleImageUrl;
     private String puzzlePlayUid;
-    private String userId;
-    private boolean isCompleted;
-    private int piecesCount;
-    private String piecesData;
+    private String puzzlePlayData;
 }

--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 public class PuzzlePlayRequest {
     @NotNull
-    private String piecesData;
+    private String puzzlePlayData;
 }

--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
@@ -10,5 +10,5 @@ public class PuzzlePlayResponse {
     private String puzzleUid;
     private Long userId;
     private boolean isCompleted;
-    private String piecesData;
+    private String puzzlePlayData;
 }

--- a/src/main/java/startoy/puzzletime/repository/PuzzlePlayRepository.java
+++ b/src/main/java/startoy/puzzletime/repository/PuzzlePlayRepository.java
@@ -18,21 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 
 @Repository
-@SqlResultSetMapping(
-    name = "GetPuzzleResponseMapping",
-    classes = @ConstructorResult(
-        targetClass = GetPuzzleResponse.class,
-        columns = {
-            @ColumnResult(name = "puzzleUid", type = String.class),
-            @ColumnResult(name = "imageUrl", type = String.class),
-            @ColumnResult(name = "puzzlePlayUid", type = String.class),
-            @ColumnResult(name = "userId", type = String.class),
-            @ColumnResult(name = "isCompleted", type = Boolean.class),
-            @ColumnResult(name = "piecesCount", type = Integer.class),
-            @ColumnResult(name = "piecesData", type = String.class)
-        }
-    )
-)
 public interface PuzzlePlayRepository extends JpaRepository<PuzzlePlay, Long> {
 
     // 퍼즐 ID로 해당 퍼즐 플레이 정보를 조회
@@ -40,34 +25,22 @@ public interface PuzzlePlayRepository extends JpaRepository<PuzzlePlay, Long> {
 
     // 퍼즐 UID와 사용자 ID로 해당 퍼즐 플레이 정보를 조회
     @Query(value =
-            "SELECT pd.puzzle_uid AS puzzleUid, pd.image_url AS imageUrl, " +
-                    "       tpp.puzzle_play_uid AS puzzlePlayUid, tpp.user_id AS userId, " +
-                    "       tpp.is_completed AS isCompleted, tpp.pieces_count AS piecesCount, tpp.pieces_data AS piecesData " +
-                    "FROM (SELECT tp.puzzle_id, tp.puzzle_uid, tis.image_url " +
-                    "      FROM tb_puzzles tp " +
-                    "      JOIN tb_image_storage tis ON tp.puzzle_image_id = tis.image_id " +
-                    "      WHERE tp.puzzle_uid = :puzzleUid) AS pd " +
-                    "LEFT JOIN tb_puzzle_play tpp " +
-                    "ON pd.puzzle_id = tpp.puzzle_id AND tpp.user_id = :userId",
+            "SELECT IFNULL(pd.puzzle_uid, '') AS puzzleUid, " +
+            "       IFNULL(pd.image_url, '') AS puzzleImageUrl, " +
+            "       IFNULL(tpp.puzzle_play_uid, '') AS puzzlePlayUid, " +
+            "       IFNULL(tpp.puzzle_play_data, '') AS puzzlePlayData " +
+            "FROM (SELECT tp.puzzle_id, tp.puzzle_uid, tis.image_url " +
+            "      FROM tb_puzzles tp " +
+            "      JOIN tb_image_storage tis ON tp.puzzle_image_id = tis.image_id " +
+            "      WHERE tp.puzzle_uid = :puzzleUid) AS pd " +
+            "LEFT JOIN tb_puzzle_play tpp " +
+            "ON pd.puzzle_id = tpp.puzzle_id AND tpp.user_id = :userId",
             nativeQuery = true
     )
     Map<String, Object> findByPuzzleUidAndUserId(
             @Param("puzzleUid") String puzzleUid,
             @Param("userId") String userId
     );
-    /* #region : native query findByPuzzleUidAndUserId
-     *    SELECT pd.puzzle_uid, pd.image_url, tpp.puzzle_play_uid, tpp.user_id, tpp.is_completed, tpp.pieces_count, tpp.pieces_data
-     *    from (select tp.puzzle_id, tp.puzzle_uid, tis.image_url
-     *                    from tb_puzzles tp
-     *                  join tb_image_storage tis
-     *                  on tp.puzzle_image_id = tis.image_id
-     *                  where tp.puzzle_uid = :puzzleUid	-- tb_puzzles 중 일치하는 퍼즐 정보 조회
-     *            ) as pd -- puzzle data
-     *    left join tb_puzzle_play tpp
-     *    on pd.puzzle_id = tpp.puzzle_id
-     *    and tpp.user_id = :userId				-- tb_puzzle_play 중 일치하는 사용자 정보 조회
-     * #endregion */
-
 
     List<PuzzlePlay> findByPuzzle_PuzzleIdAndUser_Id(Long puzzleId, Long userId);
 

--- a/src/main/java/startoy/puzzletime/service/PuzzlePlayService.java
+++ b/src/main/java/startoy/puzzletime/service/PuzzlePlayService.java
@@ -42,7 +42,7 @@ public class PuzzlePlayService {
                         .build());
 
         // 진행 상태 업데이트
-        puzzlePlay.setPiecesData(request.getPiecesData());
+        puzzlePlay.setPuzzlePlayData(request.getPuzzlePlayData());
         puzzlePlay.setUpdatedAt(LocalDateTime.now());
 
         // 저장
@@ -53,7 +53,7 @@ public class PuzzlePlayService {
                 .puzzleUid(savedPuzzlePlay.getPuzzle().getPuzzleUid())
                 .userId(savedPuzzlePlay.getUser().getId())
                 .isCompleted(savedPuzzlePlay.getIsCompleted())
-                .piecesData(savedPuzzlePlay.getPiecesData())
+                .puzzlePlayData(savedPuzzlePlay.getPuzzlePlayData())
                 .build();
     }
 }

--- a/src/main/java/startoy/puzzletime/service/PuzzleService.java
+++ b/src/main/java/startoy/puzzletime/service/PuzzleService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import startoy.puzzletime.dto.puzzle.GetPuzzleResponse;
@@ -27,17 +28,21 @@ public class PuzzleService {
         }
 
         // 필수 필드 검증
-        validateRequiredFields(result, "puzzleUid", "imageUrl");
+        validateRequiredFields(result, "puzzleUid", "puzzleImageUrl");
+
+        // puzzlePlayUid 없으면
+        String puzzlePlayUid = result.get("puzzlePlayUid").toString();
+        if (puzzlePlayUid.isEmpty()) {
+            // 신규 UID 생성
+            puzzlePlayUid = UUID.randomUUID().toString();
+        }
 
         // 값 추출 및 DTO 생성
         return GetPuzzleResponse.builder()
                 .puzzleUid(getString(result, "puzzleUid"))
-                .imageUrl(getString(result, "imageUrl"))
-                .puzzlePlayUid(getString(result, "puzzlePlayUid"))
-                .userId(getString(result, "userId"))
-                .isCompleted(getBoolean(result, "isCompleted"))
-                .piecesCount(getInt(result, "piecesCount"))
-                .piecesData(getString(result, "piecesData"))
+                .puzzleImageUrl(getString(result, "puzzleImageUrl"))
+                .puzzlePlayUid(puzzlePlayUid)
+                .puzzlePlayData(getString(result, "puzzlePlayData"))
                 .build();
     }
 


### PR DESCRIPTION
- rename piecesData -> puzzlePlayData
- rename imageUrl -> puzzleImageUrl

- modify response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- `GetPuzzleResponse`에서 `imageUrl` 필드가 `puzzleImageUrl`로 이름 변경.
	- `PuzzlePlayRequest`, `PuzzlePlayResponse`에서 `piecesData` 필드가 `puzzlePlayData`로 이름 변경.
	- 여러 필드가 `GetPuzzleResponse`에서 제거되어 데이터 구조가 간소화됨.
	- `findByPuzzleUidAndUserId` 메서드의 SQL 쿼리 간소화 및 필드 선택 변경. 
	- `savePuzzlePlay` 메서드에서 `piecesData` 대신 `puzzlePlayData` 사용. 
	- `getPuzzleByUid` 메서드에서 `puzzlePlayUid`의 유효성 검사 로직 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->