### PR TITLE
Fix JSON 변수명 isCompleted 불일치 수정

### DIFF
--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayRequest.java
@@ -1,5 +1,6 @@
 package startoy.puzzletime.dto.puzzlePlay;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -10,5 +11,6 @@ public class PuzzlePlayRequest {
     @NotNull
     private String puzzleUid;
     @NotNull
+    @JsonProperty("isCompleted")
     private boolean isCompleted;
 }

--- a/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
+++ b/src/main/java/startoy/puzzletime/dto/puzzlePlay/PuzzlePlayResponse.java
@@ -1,5 +1,6 @@
 package startoy.puzzletime.dto.puzzlePlay;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,6 +10,7 @@ public class PuzzlePlayResponse {
     private String puzzlePlayUid;
     private String puzzleUid;
     private String puzzlePlayData;
+    @JsonProperty("isCompleted")
     private boolean isCompleted;
     private String completedPuzzlesFraction; // "완료한 퍼즐 수/총 퍼즐 수" : "1/4", "2/4",,,
 }


### PR DESCRIPTION
- **Bug Fixes**
	- 변수명 isCompleted 가 completed로 인식되는 오류 수정
	- JSON 직렬화/역직렬화 과정에서 JavaBeans 표준 명명 규칙과 Jackson의 기본 동작에 의해 isCompleted가 completed로 변환됨
	- @JsonProperty("isCompleted") 추가하여 명시적으로 변수명 지정하여 해결